### PR TITLE
don't allow angular version >= 1.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,17 +17,17 @@
   ],
   "dependencies": {
     "bootstrap": "^3.3.7",
-    "angular": "^1.5.8",
-    "angular-sanitize": "^1.5.8",
-    "angular-route": "^1.5.8",
-    "angular-animate": "^1.5.8",
+    "angular": "~1.5.8",
+    "angular-sanitize": "~1.5.8",
+    "angular-route": "~1.5.8",
+    "angular-animate": "~1.5.8",
     "lodash": "^4.16.0",
     "ng-file-upload": "^12.2.9",
     "angular-ui-tree": "^2.22.0",
     "angular-simple-logger": "^0.1.7",
     "angular-ui-select": "^0.19.4",
     "ng-flags": "^0.0.2",
-    "angular-messages": "^1.5.8",
+    "angular-messages": "~1.5.8",
     "proj4": "^2.3.15",
     "world-flags-sprite": "*",
     "font-awesome": "fontawesome#^4.6.3",
@@ -38,6 +38,6 @@
     "angular-ui-router": "^0.3.2"
   },
   "resolutions": {
-    "angular": "^1.5.8"
+    "angular": "~1.5.8"
   }
 }


### PR DESCRIPTION
angular-* packages won't work with current bower.json, because they match 1.6.0 but angular itself matches 1.5.9.
Thus I allow all 1.5.x versions, but not 1.6 or higher.

Please review @eScienceCenter/spacialists 