### PR TITLE
get labels for selected language and order by label instead of url

### DIFF
--- a/lumen/app/Http/Controllers/TreeController.php
+++ b/lumen/app/Http/Controllers/TreeController.php
@@ -130,7 +130,7 @@ class TreeController extends BaseController
                 )
             SELECT  q.*
             FROM    q
-            ORDER BY concept_url ASC
+            ORDER BY label ASC
         ");
 
         $concepts = array();
@@ -186,7 +186,11 @@ class TreeController extends BaseController
         $narrower = DB::table($thConcept . ' as c')
             ->join($labelView . ' as f', 'c.concept_url', '=', 'f.concept_url')
             ->join($thBroader .' as broad', 'c.id', '=', 'broad.narrower_id')
-            ->where('broad.broader_id', '=', $id)
+            ->where([
+                [ 'broad.broader_id', '=', $id ],
+                [ 'lang', '=', $lang ]
+            ])
+            ->orderBy('label', 'asc')
             ->get();
         // broader
         $broaderIds = DB::table($thConcept . ' as c')


### PR DESCRIPTION
fix #34 

`Facetten > Flora > Bäume und Sträucher` now displays the correct narrower labels (e.g. _Ahorn_ instead of _Acer_)

Please review @eScienceCenter/spacialists 