### PR TITLE
Add user management

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-var thesaurexApp = angular.module('tutorialApp', ['ngAnimate', 'ngRoute', 'ngMessages', 'nemLogging', 'ui.select', 'ngSanitize', 'ngFlag', 'ui.bootstrap', 'ngFileUpload', 'ui.tree', 'ui.bootstrap.contextMenu']);
+var thesaurexApp = angular.module('tutorialApp', ['ngAnimate', 'satellizer', 'ui.router', 'ngRoute', 'ngMessages', 'nemLogging', 'ui.select', 'ngSanitize', 'ngFlag', 'ui.bootstrap', 'ngFileUpload', 'ui.tree', 'ui.bootstrap.contextMenu']);
 
 thesaurexApp.directive('spinner', function() {
     return {
@@ -52,7 +52,9 @@ thesaurexApp.directive('resizeWatcher', function($window) {
             var width = $window.innerWidth;
             var isSm = window.matchMedia("(max-width: 991px)").matches;
             var controlElement = $('.control-elements')[0];
-            var controlHeight = controlElement.offsetHeight + controlElement.offsetTop;
+            var controlHeight;
+            if(controlElement) controlHeight = controlElement.offsetHeight + controlElement.offsetTop;
+            else controlHeight = 0;
             if(isSm) {
                 $('#master-tree').css('height', '');
                 $('#project-tree').css('height', '');
@@ -62,12 +64,17 @@ thesaurexApp.directive('resizeWatcher', function($window) {
                 $('#alternative-list').css('height', '');
             } else {
                 var headerHeight = document.getElementById('main-container').offsetTop;
-                var informationHeight = document.getElementById('information-header').offsetHeight;
-                var informationAlertHeight = document.getElementById('information-alert').offsetHeight;
+                var informationHeight = 0;
+                var informationHeader = document.getElementById('information-header');
+                if(informationHeader) informationHeight = informationHeader.offsetHeight;
+                var informationAlertHeight = 0;
+                var informationAlert = document.getElementById('information-alert');
+                if(informationAlert) informationAlertHeight = informationAlert.offsetHeight;
                 informationHeight += informationAlertHeight;
                 //use broader-header height as subHeaderHeight, since all *-header should have the same height
                 var subHeader = document.getElementById('broader-header');
-                var subHeaderHeight = subHeader.offsetHeight + subHeader.offsetTop;
+                var subHeaderHeight = 0;
+                if(subHeader) subHeaderHeight = subHeader.offsetHeight + subHeader.offsetTop;
 
                 var containerHeight = height - controlHeight - headerHeight - bottomPadding;
                 var rightHeight = height - headerHeight - (bottomPadding - (listPadding/4)) - informationHeight - listPadding;
@@ -230,24 +237,116 @@ thesaurexApp.factory('httpGetFactory', function($http) {
     };
 });
 
-thesaurexApp.factory('scopeService', function($http) {
-    var service = {
-    };
-    return service;
-});
+thesaurexApp.config(function($stateProvider, $urlRouterProvider, $authProvider, $httpProvider, $provide) {
+    var lastError;
+    var rejectReasons = [
+        'user_not_found',
+        'token_not_provided',
+        'token_expired',
+        'token_absent',
+        'token_invalid'
+    ];
+    var rejectTranslationKeys = [
+        "login.error.user-not-found",
+        "login.error.token-not-provided",
+        "login.error.token-expired",
+        "login.error.token-absent",
+        "login.error.token-invalid"
+    ];
 
-thesaurexApp.config(function($routeProvider, $locationProvider) {
-    $routeProvider
-        .when('/tree', {
+    function updateToken(response, $injector) {
+        if(response.headers('Authorization') !== null) {
+            var token = response.headers('Authorization').replace('Bearer ', '');
+            var $auth = $injector.get('$auth');
+            $auth.setToken(token);
+            localStorage.setItem('satellizer_token', token);
+        }
+    }
+
+    function setAuthHeader($q, $injector) {
+        return {
+            response: function(response) {
+                updateToken(response, $injector);
+                return response || $q.when(response);
+            },
+            responseError: function(rejection) {
+                console.log("Something went wrong...");
+                var reasonIndex = rejectReasons.indexOf(rejection.data.error);
+                if(rejection.data && reasonIndex > -1) {
+                    localStorage.removeItem('user');
+                    var userService = $injector.get('userService');
+                    userService.loginError.message = rejectTranslationKeys[reasonIndex];
+                } else if(rejection.status == 400 || rejection.status == 401) {
+                    var $state = $injector.get('$state');
+                    var userService = $injector.get('userService');
+                    userService.loginError.message = 'login.error.400-or-401';
+                    localStorage.removeItem('user');
+                    $state.go('auth');
+                } else {
+                    updateToken(rejection, $injector);
+                    var parser = new DOMParser();
+                    var doc = parser.parseFromString(rejection.data, "text/xml");
+                    var errors = doc.getElementsByClassName('exception_message');
+                    var modalFactory = $injector.get('modalFactory');
+                    var errorMsg;
+                    if(typeof errors[0] != 'undefined' && errors[0].innerHTML) {
+                        errorMsg = errors[0].innerHTML;
+                    } else {
+                        errorMsg = rejection.statusText;
+                    }
+                    if(!lastError || lastError != rejection.status) {
+                        lastError = rejection.status;
+                        modalFactory.errorModal(errorMsg);
+                    }
+                }
+                return $q.reject(rejection);
+            }
+        };
+    }
+    $provide.factory('setAuthHeader', setAuthHeader);
+
+    $httpProvider.interceptors.push('setAuthHeader');
+
+	$authProvider.baseUrl = '.';
+    $authProvider.loginUrl = 'api/user/login';
+    $urlRouterProvider.otherwise('/auth');
+
+    $stateProvider
+        .state('auth', {
+            url: '/auth',
+            templateUrl: 'layouts/login.html',
+            controller: 'userCtrl'
+        })
+        .state('thesaurex', {
+            url: '/thesaurex',
             templateUrl: 'includes/tree.html'
         })
-        /*.when('/user/role/:activeRole', {
-            template: '',
-            controller: 'headerCtrl'
-        })*/
-        .otherwise({
-            redirectTo: '/tree'
+        .state('user', {
+            url: '/user',
+            templateUrl: 'user.html'
+        })
+        .state('roles', {
+            url: '/roles',
+            templateUrl: 'roles.html'
         });
+});
 
-    //$locationProvider.html5Mode(true);
+/**
+ * Redirect user to 'spacialist' state if they are already logged in and access the 'auth' state
+ */
+thesaurexApp.run(function($rootScope, $state, userService) {
+    $rootScope.$on('$stateChangeStart', function(event, toState) {
+        var user = localStorage.getItem('user');
+        if(user !== '') {
+            parsedUser = JSON.parse(user);
+            if(parsedUser) {
+                userService.currentUser.user = parsedUser.user;
+                userService.currentUser.permissions = parsedUser.permissions;
+                if(toState.name === 'auth') {
+                    event.preventDefault();
+                    $state.go('thesaurex');
+                }
+            }
+        }
+    });
 });

--- a/app/userService.js
+++ b/app/userService.js
@@ -1,0 +1,194 @@
+thesaurexApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'modalFactory', '$auth', '$state', '$http', function(httpPostFactory, httpGetFactory, modalFactory, $auth, $state, $http) {
+    var user = {};
+    user.currentUser = {
+        permissions: {},
+        roles: {},
+        user: {}
+    };
+    user.loginError = {};
+    user.users = [];
+    user.roles = [];
+    user.permissions = [];
+    user.can = function(to) {
+        if(typeof user.currentUser == 'undefined') return false;
+        if(typeof user.currentUser.permissions[to] == 'undefined') return false;
+        return user.currentUser.permissions[to] == 1;
+    };
+
+    user.getUserList = function() {
+        user.users.length = 0;
+        httpPostFactory('api/user/get/all', new FormData(), function(response) {
+            angular.forEach(response.users, function(u, key) {
+                user.users.push(u);
+            });
+        });
+    };
+
+    user.deleteUser = function(u) {
+        console.log(u);
+        httpGetFactory('api/user/delete/' + u.id, function(response) {
+            var index = user.users.indexOf(u);
+            if(index > -1) user.users.splice(index, 1);
+        });
+    };
+
+    user.addUser = function(name, email, password) {
+        var formData = new FormData();
+        formData.append('name', name);
+        formData.append('email', email);
+        formData.append('password', password);
+        httpPostFactory('api/user/add', formData, function(response) {
+            user.users.push(response.user);
+        });
+    };
+
+    user.editUser = function(changes, id, $index) {
+        var formData = new FormData();
+        formData.append('user_id', id);
+        for(var k in changes) {
+            if(changes.hasOwnProperty(k)) {
+                formData.append(k, changes[k]);
+            }
+        }
+        httpPostFactory('api/user/edit', formData, function(response) {
+            user.users[$index] = response.user;
+        });
+    };
+
+    user.getRoles = function() {
+        user.roles.length = 0;
+        user.permissions.length = 0;
+        httpGetFactory('api/user/get/roles/all', function(response) {
+            angular.forEach(response.permissions, function(perm) {
+                user.permissions.push(perm);
+            });
+            angular.forEach(response.roles, function(role, key) {
+                role.permissions = [];
+                user.roles.push(role);
+            });
+        });
+    };
+
+    user.getRolePermissions = function(role) {
+        if(role.permissions) role.permissions.length = 0;
+        httpGetFactory('api/user/get/role/permissions/' + role.id, function(response) {
+            angular.forEach(response.permissions, function(perm) {
+                role.permissions.push(perm);
+            });
+        });
+    };
+
+    user.openEditRoleDialog = function(role) {
+        modalFactory.editRoleModal(editRole, role);
+    };
+
+    function editRole(role, changes) {
+        var formData = new FormData();
+        if(role) formData.append('role_id', role.id);
+        for(var k in changes) {
+            if(changes.hasOwnProperty(k)) {
+                formData.append(k, changes[k]);
+            }
+        }
+        httpPostFactory('api/role/edit', formData, function(response) {
+            var isNew = false;
+            if(!role) {
+                role = {};
+                isNew = true;
+            }
+            for(var k in response.role) {
+                if(response.role.hasOwnProperty(k)) {
+                    role[k] = response.role[k];
+                }
+            }
+            if(isNew) user.roles.push(role);
+        });
+    }
+
+    user.deleteRole = function(role) {
+        httpGetFactory('api/role/delete/' + role.id, function(response) {
+            if(response.error) return;
+            var index = user.roles.indexOf(role);
+            if(index > -1) user.roles.splice(index, 1);
+        });
+    };
+
+    user.addRolePermission = function(item, role) {
+        var formData = new FormData();
+        formData.append('role_id', role.id);
+        formData.append('permission_id', item.id);
+        httpPostFactory('api/role/add/permission', formData, function(response) {
+            // if an error occurs, remove added permission
+            if(response.error) {
+                var index = role.permissions.indexOf(item);
+                if(index > -1) role.permissions.splice(index, 1);
+                return;
+            }
+        });
+    };
+
+    user.removeRolePermission = function(item, role) {
+        var formData = new FormData();
+        formData.append('role_id', role.id);
+        formData.append('permission_id', item.id);
+        httpPostFactory('api/role/remove/permission', formData, function(response) {
+            // if an error occurs, readd removed permission
+            if(response.error) {
+                role.permissions.push(item);
+                return;
+            }
+        });
+    };
+
+    user.getUserRoles = function(id, $index) {
+        httpGetFactory('api/user/get/roles/' + id, function(response) {
+            user.users[$index].roles = response.roles;
+        });
+    };
+
+    user.addUserRole = function($item, user_id) {
+        var formData = new FormData();
+        formData.append('role_id', $item.id);
+        formData.append('user_id', user_id);
+        httpPostFactory('api/user/add/role', formData, function(response) {
+            // TODO only remove/add role if function returns no error
+        });
+    };
+
+    user.removeUserRole = function($item, user_id) {
+        var formData = new FormData();
+        formData.append('role_id', $item.id);
+        formData.append('user_id', user_id);
+        httpPostFactory('api/user/remove/role', formData, function(response) {
+            // TODO only remove/add role if function returns no error
+        });
+    };
+
+    user.loginUser = function(credentials) {
+        $auth.login(credentials).then(function() {
+            return $http.post('api/user/get');
+        }).then(function(response) {
+            if(typeof response === 'undefined' || response.status !== 200) {
+                $state.go('auth', {});
+                return;
+            }
+            localStorage.setItem('user', JSON.stringify(response.data));
+            user.currentUser.user = response.data.user;
+            user.currentUser.permissions = response.data.permissions;
+            console.log(JSON.stringify(response.data));
+            delete user.loginError.message;
+            $state.go('thesaurex', {});
+        });
+    };
+
+    user.logoutUser = function() {
+        $auth.logout().then(function() {
+            user.currentUser.user = {};
+            user.currentUser.permissions = {};
+            localStorage.removeItem('user');
+            $state.go('auth', {});
+        });
+    };
+
+    return user;
+}]);

--- a/controllers/treeCtrl.js
+++ b/controllers/treeCtrl.js
@@ -1,10 +1,11 @@
-thesaurexApp.controller('treeCtrl', ['$scope', 'httpPostFactory', 'mainService', '$timeout', function($scope, httpPostFactory, mainService, $timeout) {
+thesaurexApp.controller('treeCtrl', ['$scope', 'httpPostFactory', 'mainService', 'userService', '$timeout', function($scope, httpPostFactory, mainService, userService, $timeout) {
     $scope.languages = mainService.languages;
     $scope.preferredLanguages = mainService.preferredLanguages;
     $scope.masterTree = mainService.tree.master;
     $scope.projectTree = mainService.tree.project;
     $scope.selectedElement = mainService.selectedElement;
     $scope.blockedUi = mainService.blockedUi;
+    $scope.currentUser = userService.currentUser;
 
     $scope.expandedElement = null;
 

--- a/controllers/userCtrl.js
+++ b/controllers/userCtrl.js
@@ -1,0 +1,96 @@
+thesaurexApp.controller('userCtrl', ['$scope', 'userService', '$state', 'modalFactory', function($scope, userService, $state, modalFactory) {
+    $scope.currentUser = userService.currentUser;
+    $scope.users = userService.users;
+    $scope.roles = userService.roles;
+    $scope.permissions = userService.permissions;
+    $scope.loginError = userService.loginError;
+    $scope.deleteUser = userService.deleteUser;
+
+    $scope.loginUser = function(email, password) {
+        var credentials = {
+            email: email,
+            password: password
+        };
+        userService.loginUser(credentials);
+    };
+
+    $scope.guestLogin = function() {
+        var email = 'udontneedtoseehisidentification@rebels.tld';
+        var pw = 'thesearentthedroidsuarelookingfor';
+        $scope.loginUser(email, pw);
+    };
+
+    $scope.logoutUser = function() {
+        userService.logoutUser();
+    };
+
+    $scope.openUserManagement = function() {
+        $state.go('user', {});
+    };
+
+    $scope.openRoleManagement = function() {
+        $state.go('roles', {});
+    };
+
+    $scope.openLiteratureView = function() {
+        $state.go('literature', {});
+    };
+
+    $scope.getUserList = function() {
+        userService.getUserList();
+    };
+
+    $scope.getRoles = function() {
+        userService.getRoles();
+    };
+
+    $scope.getRolePermissions = function(role) {
+        userService.getRolePermissions(role);
+    };
+
+    $scope.addRolePermission = function(item, role) {
+        userService.addRolePermission(item, role);
+    };
+
+    $scope.removeRolePermission = function(item, role) {
+        userService.removeRolePermission(item, role);
+    };
+
+    $scope.deleteRole = function(role) {
+        userService.deleteRole(role);
+    };
+
+    $scope.openAddRoleDialog = function() {
+        userService.openEditRoleDialog();
+    };
+
+    $scope.openEditRoleDialog = function(role) {
+        userService.openEditRoleDialog(role);
+    };
+
+    $scope.getUserRoles = function(id, $index) {
+        userService.getUserRoles(id, $index);
+    };
+
+    $scope.addUserRole = function($item, user_id) {
+        userService.addUserRole($item, user_id);
+    };
+
+    $scope.removeUserRole = function($item, user_id) {
+        userService.removeUserRole($item, user_id);
+    };
+
+    $scope.openAddUserDialog = function() {
+        modalFactory.addUserModal(userService.addUser);
+    };
+
+    $scope.openEditUserDialog = function(user, $index) {
+        var values = {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            password: ''
+        };
+        modalFactory.editUserModal(userService.editUser, values, $index);
+    };
+}]);

--- a/includes/tree.html
+++ b/includes/tree.html
@@ -3,7 +3,7 @@
         <div class="col-md-6" ng-controller="masterCtrl">
             <div class="control-elements">
                 <h2>Master Thesaurus</h2>
-                <div class="btn-group" uib-dropdown>
+                <div class="btn-group" uib-dropdown ng-if="currentUser.permissions.add_move_concepts_th">
                     <button type="file" id="default-import-master" class="btn btn-default" ngf-select="uploadFile($file, $invalidFiles)" accept="application/rdf+xml,text/plain,application/x-turtle" ngf-max-size="10MB">
                         Import RDF
                     </button>
@@ -17,8 +17,10 @@
                         <li role="menuitem"><a href="#" type="file" ngf-select="uploadFile($file, $invalidFiles, 'new')" accept="application/rdf+xml,text/plain,application/x-turtle" ngf-max-size="10MB">Replace thesaurus with import</a></li>
                     </ul>
                 </div>
-                <button type="button" class="btn btn-default" ng-click="export(treeName)">Export RDF</button>
-                <div class="search-container">
+                <button type="button" class="btn btn-default" ng-click="export(treeName)" ng-if="currentUser.permissions.export_th">
+                    Export RDF
+                </button>
+                <div class="search-container" ng-if="currentUser.permissions.view_concepts_th">
                     <div class="input-group">
                         <input type="text" class="form-control" ng-model="selectedSearchVal[treeName]" ng-model-options="{ debounce: 250 }" placeholder="Search" uib-typeahead="result.label + ' (' + result.broader_label + ')' for result in getSearchTree($viewValue, treeName)" typeahead-min-length="3" typeahead-wait-ms="50" typeahead-on-select="expandElement($item, treeName)" typeahead-loading="loadingResults[treeName]" typeahead-no-results="noResults[treeName]">
                         <span class="input-group-addon"><i class="fa fa-fw fa-search"></i></span>
@@ -29,17 +31,17 @@
                     </div>
                 </div>
                 <label class="checkbox-inline"><input type="checkbox" value="" ng-model="enableDragDrop" ng-disabled="!masterTree.tree"/>Enable Drag & Drop</label>
-                <label class="checkbox-inline"><input type="checkbox" value="" ng-model="enableEditing" ng-disabled="!masterTree.tree"/>Enable Editing</label>
             </div>
+            <!-- TODO enableEditing = isAllowedToEditMasterTree -->
             <div id="master-tree" ui-tree="treeOptions" data-clone-enabled="true" data-nodrop-enabled="!enableEditing" data-drag-enabled="enableDragDrop" data-drag-delay="1000" data-expand-on-hover="true" ng-show="masterTree.tree">
                 <ul ui-tree-nodes ng-model="masterTree.tree" style="margin-bottom: 8px;">
-                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)">
+                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         <i class="fa fa-fw"></i>
                         Create New Top-Level Concept
                     </li>
                     <li ng-repeat="parent in masterTree.tree" context-menu="getContextMenu(parent, treeName)" ui-tree-node ng-include="'includes/subTree.html'">
                     </li>
-                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)">
+                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         <i class="fa fa-fw"></i>
                         Create New Top-Level Concept
                     </li>
@@ -53,7 +55,7 @@
         <div class="col-md-6" ng-controller="projectCtrl">
             <div class="control-elements">
                 <h2>Project Thesaurus</h2>
-                <div class="btn-group" uib-dropdown>
+                <div class="btn-group" uib-dropdown ng-if="currentUser.permissions.add_move_concepts_th">
                     <button type="file" id="default-import-project" class="btn btn-default" ngf-select="uploadFile($file, $invalidFiles, 'new', treeName)" accept="application/rdf+xml,text/plain,application/x-turtle" ngf-max-size="10MB">
                         Import RDF
                     </button>
@@ -67,8 +69,10 @@
                         <li role="menuitem"><a href="#" type="file" ngf-select="uploadFile($file, $invalidFiles, 'new', treeName)" accept="application/rdf+xml,text/plain,application/x-turtle" ngf-max-size="10MB">Replace thesaurus with upload</a></li>
                     </ul>
                 </div>
-                <button type="button" class="btn btn-default" ng-click="export(treeName)">Export RDF</button>
-                <div class="search-container">
+                <button type="button" class="btn btn-default" ng-click="export(treeName)" ng-if="currentUser.permissions.export_th">
+                    Export RDF
+                </button>
+                <div class="search-container" ng-if="currentUser.permissions.view_concepts_th">
                     <div class="input-group">
                         <input type="text" class="form-control" ng-model="selectedSearchVal[treeName]" ng-model-options="{ debounce: 250 }" placeholder="Search" uib-typeahead="result.label + ' (' + result.broader_label + ')' for result in getSearchTree($viewValue, treeName)" typeahead-min-length="3" typeahead-wait-ms="50" typeahead-on-select="expandElement($item, treeName)" typeahead-loading="loadingResults[treeName]" typeahead-no-results="noResults[treeName]">
                         <span class="input-group-addon"><i class="fa fa-fw fa-search"></i></span>
@@ -82,13 +86,13 @@
             </div>
             <div id="project-tree" ui-tree="exportTreeOptions" data-nodrop-enabled="!enableExportDragDrop" data-drag-enabled="enableExportDragDrop" data-drag-delay="1000" data-expand-on-hover="true">
                 <ul ui-tree-nodes ng-model="projectTree.tree" style="margin-bottom: 8px;">
-                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)">
+                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         <i class="fa fa-fw"></i>
                         Create New Top-Level Concept
                     </li>
                     <li ng-repeat="parent in projectTree.tree" context-menu="getContextMenu(parent, treeName)" ui-tree-node ng-include="'includes/subTree.html'">
                     </li>
-                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)">
+                    <li class="new-concept-dummy" ng-click="createNewConceptModal(treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         <i class="fa fa-fw"></i>
                         Create New Top-Level Concept
                     </li>
@@ -101,7 +105,7 @@
             Choose an element from either tree to display its properties.
         </p>
     </div>
-    <div class="col-md-6" ng-class="{'my-hidden': !selectedElement.properties.id}">
+    <div class="col-md-6" ng-class="{'my-hidden': !selectedElement.properties.id}" ng-if="currentUser.permissions.view_concepts_th">
         <div id="information-header" class="relation-header">
             <h2>{{ selectedElement.properties.label }} <small>Concept Details</small></h2>
             <div class="col-md-12">
@@ -113,7 +117,7 @@
         <div class="col-md-6">
             <div id="broader-header" class="relation-header">
                 <h3>Broader Concepts</h3>
-                <div class="search-container">
+                <div class="search-container" ng-if="currentUser.permissions.add_move_concepts_th">
                     <div class="input-group">
                         <input type="text" class="form-control" ng-model="broaderSearch" ng-model-options="{ debounce: 250 }" placeholder="Type to search broader concept" uib-typeahead="result.label + ' (' + result.broader_label + ')' for result in getSearchTree($viewValue, selectedElement.treeName)" typeahead-min-length="3" typeahead-wait-ms="50" typeahead-on-select="addBroader($item, selectedElement.treeName)" typeahead-loading="loadingBroaderSearchResults" typeahead-no-results="noBroaderFound" />
                         <span class="input-group-addon"><i class="fa fa-fw fa-search"></i></span>
@@ -124,13 +128,13 @@
                     </div>
                 </div>
             </div>
-            <ul id="broader-list" class="scrollable-list">
+            <ul id="broader-list" class="scrollable-list" ng-if="currentUser.permissions.view_concepts_th">
                 <div ng-if="!selectedElement.relations.broader || selectedElement.relations.broader.length == 0">
                     <i>No broader concepts defined.</i>
                 </div>
                 <li ng-repeat="br in selectedElement.relations.broader" ng-mouseenter="hovered=true;" ng-mouseleave="hovered=false;">
                     <span ng-show="hovered" class="delete-icon-l"
-                    ng-click="deleteBroaderConcept($index, br, selectedElement.treeName)">
+                    ng-click="deleteBroaderConcept($index, br, selectedElement.treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         &times;
                     </span>
                     <strong>{{ br.label }}</strong>
@@ -140,7 +144,7 @@
             </ul>
             <div id="narrower-header" class="relation-header">
                 <h3>Narrower Concepts</h3>
-                <div class="search-container">
+                <div class="search-container" ng-if="currentUser.permissions.add_move_concepts_th">
                     <div class="input-group">
                         <input type="text" class="form-control" ng-model="narrowerSearch" ng-model-options="{ debounce: 250 }" placeholder="Type to search or create narrower concept" uib-typeahead="result.label + ' (' + result.broader_label + ')' for result in getSearchTree($viewValue, selectedElement.treeName, true)" typeahead-min-length="3" typeahead-wait-ms="50" typeahead-on-select="addNarrower($item, selectedElement.treeName)" typeahead-loading="loadingNarrowerSearchResults" typeahead-no-results="noNarrowerFound" />
                         <span class="input-group-addon"><i class="fa fa-fw fa-search"></i></span>
@@ -151,13 +155,13 @@
                     </div>
                 </div>
             </div>
-            <ul id="narrower-list" class="scrollable-list">
+            <ul id="narrower-list" class="scrollable-list" ng-if="currentUser.permissions.view_concepts_th">
                 <div ng-if="!selectedElement.relations.narrower || selectedElement.relations.narrower.length == 0">
                     <i>No narrower concepts defined.</i>
                 </div>
                 <li ng-repeat="na in selectedElement.relations.narrower" ng-mouseenter="hovered=true;" ng-mouseleave="hovered=false;">
                     <span ng-show="hovered" class="delete-icon-l"
-                    ng-click="deleteNarrowerConcept($index, na, selectedElement.treeName)">
+                    ng-click="deleteNarrowerConcept($index, na, selectedElement.treeName)" ng-if="currentUser.permissions.add_move_concepts_th">
                         &times;
                     </span>
                     <strong>{{ na.label }}</strong>
@@ -172,7 +176,7 @@
                 <div ng-if="selectedElement.loading.prefLabels">
                     <spinner/>
                 </div>
-                <div ng-show="!selectedElement.loading.prefLabels">
+                <div ng-show="!selectedElement.loading.prefLabels" ng-if="currentUser.permissions.edit_concepts_th">
                     <div class="input-group">
                         <div class="input-group-btn" uib-dropdown>
                             <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -195,13 +199,13 @@
                     </div>
                 </div>
             </div>
-            <ul id="preferred-list" class="scrollable-list">
+            <ul id="preferred-list" class="scrollable-list" ng-if="currentUser.permissions.view_concepts_th">
                 <div ng-if="!selectedElement.labels.pref || selectedElement.labels.pref.length == 0">
                     <i>No preferred labels defined.</i>
                 </div>
                 <li ng-repeat="pl in selectedElement.labels.pref" ng-mouseenter="hovered=true;" ng-mouseleave="hovered=false;">
                     <span ng-show="hovered" class="delete-icon-l"
-                    ng-click="deletePrefLabel($index, pl, selectedElement.treeName)">
+                    ng-click="deletePrefLabel($index, pl, selectedElement.treeName)" ng-if="currentUser.permissions.edit_concepts_th">
                         &times;
                     </span>
                     <span class="lang">{{ pl.langName }} <flag country="{{ getLanguageCode(pl.langShort) }}" size="16"></flag></span>
@@ -209,10 +213,10 @@
                         <i>
                             {{ pl.label }}
                         </i>
-                        <i class="fa fa-pencil edit-entry" ng-click="editPrefLabelEntry(pl)">
+                        <i class="fa fa-pencil edit-entry" ng-click="editPrefLabelEntry(pl)" ng-if="currentUser.permissions.edit_concepts_th">
                         </i>
                     </div>
-                    <div ng-if="pl.editMode">
+                    <div ng-if="pl.editMode && currentUser.permissions.edit_concepts_th">
                         <input type="text" class="inline-edit" ng-model="pl.editText" />
                         <button class="btn btn-success btn-xs" ng-click="storePrefLabelEdit(pl, selectedElement.treeName)"><i class="fa fa-check"></i></button>
                         <button class="btn btn-danger btn-xs" ng-click="resetPrefLabelEdit(pl)"><i class="fa fa-ban"></i></button>
@@ -224,7 +228,7 @@
                 <div ng-if="selectedElement.loading.altLabels">
                     <spinner/>
                 </div>
-                <div ng-show="!selectedElement.loading.altLabels">
+                <div ng-show="!selectedElement.loading.altLabels" ng-if="currentUser.permissions.edit_concepts_th">
                     <div class="input-group">
                         <div class="input-group-btn" uib-dropdown>
                             <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -246,13 +250,13 @@
                     </div>
                 </div>
             </div>
-            <ul id="alternative-list" class="scrollable-list">
+            <ul id="alternative-list" class="scrollable-list" ng-if="currentUser.permissions.view_concepts_th">
                 <div ng-if="!selectedElement.labels.alt || selectedElement.labels.alt.length == 0">
                     <i>No alternative labels defined.</i>
                 </div>
                 <li ng-repeat="al in selectedElement.labels.alt" ng-mouseenter="hovered=true;" ng-mouseleave="hovered=false;">
                     <span ng-show="hovered" class="delete-icon-l"
-                    ng-click="deleteAltLabel($index, al, selectedElement.treeName)">
+                    ng-click="deleteAltLabel($index, al, selectedElement.treeName)" ng-if="currentUser.permissions.edit_concepts_th">
                         &times;
                     </span>
                     <span class="lang">{{ al.langName }} <flag country="{{ getLanguageCode(al.langShort) }}" size="16"></flag></span>
@@ -260,10 +264,10 @@
                         <i>
                             {{ al.label }}
                         </i>
-                        <i class="fa fa-pencil edit-entry" ng-click="editAltLabelEntry(al)">
+                        <i class="fa fa-pencil edit-entry" ng-click="editAltLabelEntry(al)" ng-if="currentUser.permissions.edit_concepts_th">
                         </i>
                     </div>
-                    <div ng-if="al.editMode">
+                    <div ng-if="al.editMode && currentUser.permissions.edit_concepts_th">
                         <input type="text" class="inline-edit" ng-model="al.editText" />
                         <button class="btn btn-success btn-xs" ng-click="storeAltLabelEdit(al, selectedElement.treeName)"><i class="fa fa-check"></i></button>
                         <button class="btn btn-danger btn-xs" ng-click="resetAltLabelEdit(al)"><i class="fa fa-ban"></i></button>
@@ -271,6 +275,9 @@
                 </li>
             </ul>
         </div>
+    </div>
+    <div class="col-md-6" ng-if="!currentUser.permissions.view_concepts_th">
+        <div ng-include="'layouts/restricted-access.html'"></div>
     </div>
     <div id="loadingUi" ng-if="blockedUi.isBlocked">
         <h2>{{ blockedUi.message }}</h2>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <title>ThesauRex - Thesaurus Editor</title>
     </head>
     <body>
-        <nav id="header-nav" class="navbar navbar-inverse" role="navigation">
+        <nav id="header-nav" class="navbar navbar-inverse" role="navigation" ng-controller="userCtrl">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle"
@@ -30,14 +30,33 @@
                 </div>
                 <div class="navbar-collapse" id="navbar-collapse" uib-collapse="isCollapsed">
                     <ul class="nav navbar-nav navbar-right">
-                        <li>
-                            <img src="img/escience-logo-transparent.svg" style="width: 200px; padding: 10px;"/>
+                        <li ng-if="currentUser.user.name">
+                            <a href="" ng-click="logoutUser()">
+                                <span class="fa fa-fw fa-sign-out"></span> {{ currentUser.user.name }}
+                            </a>
                         </li>
-                      </ul>
+                        <li ng-if="currentUser.permissions.view_users || currentUser.permissions.add_edit_role" class="dropdown" uib-dropdown>
+                            <a href="#" class="dropdown-toggle" uib-dropdown-toggle data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                                {{'main.menu.user-management'}} <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu" uib-dropdown-menu>
+                                <li ng-if="currentUser.permissions.view_users">
+                                    <a href="" ng-click="openUserManagement()">
+                                        <i class="fa fa-fw fa-users"></i> {{'main.menu.user-list'}}
+                                    </a>
+                                </li>
+                                <li ng-if="currentUser.permissions.add_edit_role">
+                                    <a href="" ng-click="openRoleManagement()">
+                                        <i class="fa fa-fw fa-cog"></i> {{'main.menu.role-list'}}
+                                    </a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </div>
             </div>
         </nav>
-        <div ng-view ui-view id="main-container" class="col-md-12"></div>
+        <div ui-view id="main-container" class="col-md-12"></div>
         <script src="bower_components/jquery/dist/jquery.min.js"></script>
         <script src="bower_components/lodash/dist/lodash.min.js"></script>
         <script src="bower_components/angular/angular.min.js"></script>
@@ -58,6 +77,8 @@
         <script src="bower_components/proj4/dist/proj4.js"></script>
         <script src="app.js"></script>
         <script src="app/mainService.js"></script>
+        <script src="app/userService.js"></script>
         <script src="controllers/treeCtrl.js"></script>
+        <script src="controllers/userCtrl.js"></script>
     </body>
 </html>

--- a/layouts/login.html
+++ b/layouts/login.html
@@ -1,0 +1,32 @@
+<div class="col-md-4 col-md-offset-4">
+    <div class="well">
+        <h2>{{ 'login.title' }}</h2>
+        <form ng-submit="loginUser(user.email, user.pw)">
+            <div class="form-group">
+                <label for="email">{{ 'user.email' }}</label>
+                <div class="input-group">
+                    <div class="input-group-addon">
+                        <i class="fa fa-fw fa-envelope"></i>
+                    </div>
+                    <input id="email" class="form-control" type="text" placeholder="{{'user.email'}}" ng-model="user.email" />
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="pw">{{ 'user.password' }}</label>
+                <div class="input-group">
+                    <div class="input-group-addon">
+                        <i class="fa fa-fw fa-unlock-alt"></i>
+                    </div>
+                    <input id="pw" class="form-control" type="password" placeholder="{{'user.password'}}" ng-model="user.pw" />
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">{{ 'login.submit' }}</button>
+            <button type="button" class="btn btn-default" ng-click="guestLogin()">{{ 'login.as-guest' }}</button>
+        </form>
+        <div ng-if="loginError.message.length > 0" style="padding-top: 10px;">
+            <p class="alert alert-info unpadded-alert">
+                {{ loginError.message }}
+            </p>
+        </div>
+    </div>
+</div>

--- a/layouts/restricted-access.html
+++ b/layouts/restricted-access.html
@@ -1,0 +1,3 @@
+<div class="alert alert-warning restricted-warning">
+    You are not allowed to access this page. Pick a role with higher privileges (if possible) or contact your administrator.
+</div>

--- a/lumen/app/Http/Controllers/TreeController.php
+++ b/lumen/app/Http/Controllers/TreeController.php
@@ -44,6 +44,12 @@ class TreeController extends Controller
     }
 
     public function import(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_move_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->hasFile('file') || !$request->file('file')->isValid()) return response()->json('null');
         $file = $request->file('file');
         $type = $request->get('type');
@@ -222,6 +228,12 @@ class TreeController extends Controller
     }
 
     public function export(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('export_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if($request->has('format')) $format = $request->get('format');
         else $format = 'rdf';
         $treeName = $request->get('treeName');
@@ -331,6 +343,12 @@ class TreeController extends Controller
     }
 
     public function getAnyLabel($thesaurus_url, $suffix = '') {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
         $thBroader = 'th_broaders' . $suffix;
@@ -344,6 +362,12 @@ class TreeController extends Controller
     }
 
     public function getLabel($thesaurus_url, $suffix = '', $lang = 'de') {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
         $thBroader = 'th_broaders' . $suffix;
@@ -360,6 +384,12 @@ class TreeController extends Controller
     }
 
     public function getLabelById($id, $suffix = '', $lang = 'de') {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
         $label = DB::table($thLabel .' as lbl')
@@ -375,6 +405,12 @@ class TreeController extends Controller
     }
 
     public function getLabels(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $treeName = $request->get('treeName');
         $suffix = $treeName == 'project' ? '_export' : '';
@@ -392,6 +428,12 @@ class TreeController extends Controller
     }
 
     public function getDisplayLabel(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         if($request->has('lang')) $lang = $request->get('lang');
         else $lang = 'de';
@@ -422,6 +464,12 @@ class TreeController extends Controller
     }
 
     public function getLanguages() {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         return response()->json(
             DB::table('th_language')
                 ->select('id', 'display_name', 'short_name')
@@ -430,6 +478,12 @@ class TreeController extends Controller
     }
 
     public function getTree(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if($request->has('treeName')) $which = $request->get('treeName');
         else $which = 'master';
         if($request->has('lang')) $lang = $request->get('lang');
@@ -510,6 +564,12 @@ class TreeController extends Controller
     }
 
     public function getRelations(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->has('id')) {
             return response()->json([
                 'error' => 'id field is mandatory'
@@ -567,6 +627,12 @@ class TreeController extends Controller
     }
 
     public function deleteElementCascade(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('delete_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
@@ -582,6 +648,12 @@ class TreeController extends Controller
     }
 
     public function deleteElementOneUp(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('delete_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $broader_id = $request->get('broader_id');
         $treeName = $request->get('treeName');
@@ -629,6 +701,12 @@ class TreeController extends Controller
     }
 
     public function removeConcept(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('delete_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
@@ -686,6 +764,12 @@ class TreeController extends Controller
     }
 
     public function addBroader(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_move_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $broader = $request->get('broader_id');
         $treeName = $request->get('treeName');
@@ -707,6 +791,12 @@ class TreeController extends Controller
     }
 
     public function addConcept(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_move_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $projName = $request->get('projName');
         $scheme = $request->get('concept_scheme');
         $label = $request->get('prefLabel');
@@ -765,6 +855,12 @@ class TreeController extends Controller
     }
 
     public function removeLabel(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('edit_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
@@ -779,6 +875,12 @@ class TreeController extends Controller
     }
 
     public function addLabel(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('edit_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $label = $request->get('text');
         $lang = $request->get('lang');
         $type = $request->get('type');
@@ -830,6 +932,12 @@ class TreeController extends Controller
     }
 
     public function copy(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_move_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         // Copy elements from source tree to cloned tree and vice versa
         $elemId = $request->get('id');
         $newBroader = $request->get('new_broader');
@@ -1019,6 +1127,12 @@ class TreeController extends Controller
     }
 
     public function updateRelation(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_move_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $narrow = $request->get('narrower_id');
         $oldBroader = $request->get('old_broader_id');
         $broader = $request->get('broader_id');
@@ -1114,6 +1228,12 @@ class TreeController extends Controller
     }
 
     public function search(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->has('val')) return response()->json();
         $val = $request->get('val');
         if($request->has('treeName')) $which = $request->get('treeName');
@@ -1155,6 +1275,12 @@ class TreeController extends Controller
     }
 
     public function getAllParents(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('view_concepts_th')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->has('id')) return response()->json();
         $id = $request->get('id');
         $where = "WHERE narrower_id = $id";

--- a/lumen/app/Http/Controllers/UserController.php
+++ b/lumen/app/Http/Controllers/UserController.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\Request;
+use App\User;
+use App\Role;
+use App\Permission;
+use DB;
+use Tymon\JWTAuth\JWTAuth;
+use Zizaco\Entrust;
+
+class UserController extends Controller
+{
+    /*
+    Entrust::hasRole($role);
+    Entrust::can('view_concepts');
+     */
+    /**
+     * @var \Tymon\JWTAuth\JWTAuth
+     */
+    protected $jwt;
+
+    public function __construct(JWTAuth $jwt) {
+        $this->jwt = $jwt;
+    }
+
+    public function getUserPermissions() {
+        $user = \Auth::user();
+        return response()->json(
+            $this->getUserPermissionsById($user->id)
+        );
+    }
+
+    private function getUserPermissionsById($id) {
+        $permissions = DB::table('role_user as ru')
+            ->select('p.name')
+            ->join('permission_role as pr', 'ru.role_id', '=', 'pr.role_id')
+            ->join('permissions as p', 'p.id', '=', 'pr.permission_id')
+            ->orderBy('id')
+            ->groupBy('id')
+            ->where('user_id', '=', $id)
+            ->get();
+        $hash = [];
+        foreach($permissions as $p) {
+            $hash[$p->name] = '1';
+        }
+        return $hash;
+    }
+
+    public function get() {
+        $user = \Auth::user();
+        $permissions = $this->getUserPermissionsById($user->id);
+        return response()->json([
+            'user' => $user,
+            'permissions' => $permissions
+        ]);
+    }
+
+    public function getAll() {
+        $user = \Auth::user();
+        if(!$user->can('view_users')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        return response()->json([
+            'users' => User::all()
+        ]);
+    }
+
+    public function delete($id) {
+        $user = \Auth::user();
+        if(!$user->can('delete_users')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $toDelete = User::find($id);
+        $toDelete->delete();
+    }
+
+    public function add(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('create_users')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $name = $request->get('name');
+        $email = $request->get('email');
+        $password = Hash::make($request->get('password'));
+
+        $newUser = new User();
+        $newUser->name = $name;
+        $newUser->email = $email;
+        $newUser->password = $password;
+        $newUser->save();
+
+        return response()->json([
+            'user' => $newUser
+        ]);
+    }
+
+    public function getRoles() {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_role') && !$user->can('add_edit_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        return response()->json([
+            'roles' => Role::all(),
+            'permissions' => Permission::all()
+        ]);
+    }
+
+    public function getPermissionsByRole($id) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        return response()->json([
+            'permissions' => DB::table('permissions as p')
+                                ->select('p.*')
+                                ->join('permission_role as pr', 'pr.permission_id', '=', 'p.id')
+                                ->where('pr.role_id', '=', $id)
+                                ->get()
+        ]);
+    }
+
+    public function getRolesByUser($id) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        return response()->json([
+            'roles' => DB::table('role_user as ru')
+                ->select('r.id', 'r.name', 'r.display_name', 'r.description')
+                ->join('roles as r', 'ru.role_id', '=', 'r.id')
+                ->where('ru.user_id', '=', $id)
+                ->get()
+        ]);
+    }
+
+    public function addRoleToUser(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $role_id = $request->get('role_id');
+        $user_id = $request->get('user_id');
+        $selectedUser = User::find($user_id);
+        $selectedUser->attachRole($role_id);
+    }
+
+    public function removeRoleFromUser(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $role_id = $request->get('role_id');
+        $user_id = $request->get('user_id');
+        $selectedUser = User::find($user_id);
+        $selectedUser->detachRole($role_id);
+    }
+
+    public function edit(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('change_password')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $user_id = $request->get('user_id');
+        $editedUser = User::find($user_id);
+        //$keys = ['name', 'email', 'password'];
+        $keys = ['password']; //currently only password is supported
+        $updated = false;
+        foreach($keys as $key) {
+            if($request->has($key)) {
+                $value = $request->get($key);
+                if($key == 'password') $value = Hash::make($value);
+                $editedUser->{$key} = $value;
+                $updated = true;
+            }
+        }
+        if($updated) $editedUser->save();
+        return response()->json([
+            'user' => $editedUser
+        ]);
+    }
+
+    public function editRole(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_edit_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        if($request->has('role_id')) {
+            $role_id = $request->get('role_id');
+            $editedRole = Role::find($role_id);
+        } else {
+            $editedRole = new Role();
+        }
+        $keys = ['name', 'display_name', 'description'];
+        $updated = false;
+        foreach($keys as $key) {
+            if($request->has($key)) {
+                $value = $request->get($key);
+                $editedRole->{$key} = $value;
+                $updated = true;
+            }
+        }
+        if($updated) $editedRole->save();
+        return response()->json([
+            'role' => $editedRole
+        ]);
+    }
+
+    public function deleteRole($id) {
+        $user = \Auth::user();
+        if(!$user->can('delete_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        Role::find($id)->delete();
+        return response()->json();
+    }
+
+    public function addRolePermission(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $roleId = $request->get('role_id');
+        $permId = $request->get('permission_id');
+        DB::table('permission_role')
+            ->insert([
+                'role_id' => $roleId,
+                'permission_id' => $permId
+            ]);
+        return response()->json();
+    }
+
+    public function removeRolePermission(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        $roleId = $request->get('role_id');
+        $permId = $request->get('permission_id');
+        DB::table('permission_role')
+            ->where([
+                ['role_id', '=', $roleId],
+                ['permission_id', '=', $permId]
+            ])
+            ->delete();
+        return response()->json();
+    }
+
+    public function login(Request $request) {
+        $this->validate($request, [
+            'email'    => 'required|email|max:255',
+            'password' => 'required',
+        ]);
+
+        $valid = $this->validateRequest($request->only('email', 'password'));
+        if($valid['status'] == 200) {
+            return response()->json($valid['token']);
+        } else {
+            return response()->json($valid, $valid['status']);
+        }
+    }
+
+    private function validateRequest($request) {
+        try {
+            if(!$token = $this->jwt->attempt($request)) {
+                return [
+                    'error' => 'user_not_found',
+                    'status' => 404
+                ];
+            }
+        } catch(\Tymon\JWTAuth\Exceptions\TokenExpiredException $e) {
+            return [
+                'error' => 'token_expired',
+                'status' => 500
+            ];
+        } catch (\Tymon\JWTAuth\Exceptions\TokenInvalidException $e) {
+            return [
+                'error' => 'token_invalid',
+                'status' => 500
+            ];
+        } catch (\Tymon\JWTAuth\Exceptions\JWTException $e) {
+            return [
+                'error' => 'token_absent',
+                'status' => 500
+            ];
+        }
+        return [
+            'error' => '',
+            'status' => 200,
+            'token' => compact('token')
+        ];
+    }
+
+    private function validateToken() {
+        try {
+            if(!$user = JWTAuth::parseToken()->authenticate()) {
+                return [
+                    'error' => 'user_not_found',
+                    'status' => 404
+                ];
+            }
+        } catch (Tymon\JWTAuth\Exceptions\TokenExpiredException $e) {
+            return [
+                'error' => 'token_expired',
+                'status' => 500
+            ];
+        } catch (Tymon\JWTAuth\Exceptions\TokenInvalidException $e) {
+            return [
+                'error' => 'token_invalid',
+                'status' => 500
+            ];
+        } catch (Tymon\JWTAuth\Exceptions\JWTException $e) {
+            return [
+                'error' => 'token_absent',
+                'status' => 500
+            ];
+        }
+        return [
+            'user' => $user,
+            'status' => 200
+        ];
+    }
+}

--- a/lumen/app/Permission.php
+++ b/lumen/app/Permission.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App;
+
+use Zizaco\Entrust\EntrustPermission;
+
+class Permission extends EntrustPermission
+{
+}

--- a/lumen/app/Providers/AuthServiceProvider.php
+++ b/lumen/app/Providers/AuthServiceProvider.php
@@ -31,9 +31,10 @@ class AuthServiceProvider extends ServiceProvider
         // the User instance via an API token or any other method necessary.
 
         $this->app['auth']->viaRequest('api', function ($request) {
-            if ($request->input('api_token')) {
+            /*if ($request->input('api_token')) {
                 return User::where('api_token', $request->input('api_token'))->first();
-            }
+            }*/
+	    return \App\User::where('email', $request->input('email'))->first();
         });
     }
 }

--- a/lumen/app/Role.php
+++ b/lumen/app/Role.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App;
+
+use Zizaco\Entrust\EntrustRole;
+
+class Role extends EntrustRole
+{
+}

--- a/lumen/app/User.php
+++ b/lumen/app/User.php
@@ -7,10 +7,13 @@ use Laravel\Lumen\Auth\Authorizable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Tymon\JWTAuth\Contracts\JWTSubject;
+use Zizaco\Entrust\Traits\EntrustUserTrait;
 
-class User extends Model implements AuthenticatableContract, AuthorizableContract
+class User extends Model implements JWTSubject, AuthenticatableContract, AuthorizableContract
 {
-    use Authenticatable, Authorizable;
+    use EntrustUserTrait;
+    use Authenticatable;//, Authorizable;
 
     /**
      * The attributes that are mass assignable.
@@ -29,4 +32,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $hidden = [
         'password',
     ];
+
+    public function getJWTIdentifier() {
+	return $this->getKey();
+    }
+
+    public function getJWTCustomClaims() {
+	return [];
+    }
 }

--- a/lumen/bootstrap/app.php
+++ b/lumen/bootstrap/app.php
@@ -79,9 +79,11 @@ $app->singleton('filesystem', function ($app) {
 //    App\Http\Middleware\ExampleMiddleware::class
 // ]);
 
-// $app->routeMiddleware([
-//     'auth' => App\Http\Middleware\Authenticate::class,
-// ]);
+$app->routeMiddleware([
+//    'auth' => App\Http\Middleware\Authenticate::class,
+    'jwt.auth'    => Tymon\JWTAuth\Middleware\GetUserFromToken::class,
+    'jwt.refresh' => Tymon\JWTAuth\Middleware\RefreshToken::class,
+]);
 
 /*
 |--------------------------------------------------------------------------
@@ -97,6 +99,8 @@ $app->singleton('filesystem', function ($app) {
 // $app->register(App\Providers\AppServiceProvider::class);
 // $app->register(App\Providers\AuthServiceProvider::class);
 // $app->register(App\Providers\EventServiceProvider::class);
+$app->register(Tymon\JWTAuth\Providers\LumenServiceProvider::class);
+$app->register(Zizaco\Entrust\EntrustServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------

--- a/lumen/composer.json
+++ b/lumen/composer.json
@@ -8,7 +8,9 @@
         "php": ">=5.6.4",
         "laravel/lumen-framework": "5.3.*",
         "vlucas/phpdotenv": "~2.2",
+        "tymon/jwt-auth": "^1.0@dev",
         "league/flysystem": " ~1.0",
+        "zizaco/entrust": "1.8.0-alpha1",
         "easyrdf/easyrdf": "*",
         "semsol/arc2": "dev-master"
     },

--- a/lumen/config/auth.php
+++ b/lumen/config/auth.php
@@ -1,0 +1,93 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Defaults
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default authentication "guard" and password
+    | reset options for your application. You may change these defaults
+    | as required, but they're a perfect start for most applications.
+    |
+    */
+
+    'defaults' => [
+        'guard' => env('AUTH_GUARD', 'api'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Guards
+    |--------------------------------------------------------------------------
+    |
+    | Next, you may define every authentication guard for your application.
+    | Of course, a great default configuration has been defined for you
+    | here which uses session storage and the Eloquent user provider.
+    |
+    | All authentication drivers have a user provider. This defines how the
+    | users are actually retrieved out of your database or other storage
+    | mechanisms used by this application to persist your user's data.
+    |
+    | Supported: "session", "token"
+    |
+    */
+
+    'guards' => [
+        'api' => [
+            'driver' => 'jwt',
+            'provider' => 'users'
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Providers
+    |--------------------------------------------------------------------------
+    |
+    | All authentication drivers have a user provider. This defines how the
+    | users are actually retrieved out of your database or other storage
+    | mechanisms used by this application to persist your user's data.
+    |
+    | If you have multiple user tables or models you may configure multiple
+    | sources which represent each model / table. These sources may then
+    | be assigned to any extra authentication guards you have defined.
+    |
+    | Supported: "database", "eloquent"
+    |
+    */
+   'model' => \App\User::class,
+
+    'providers' => [
+        'users' => [
+            'driver' => 'eloquent',
+            'model'  => \App\User::class,
+            'table'  => 'users',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resetting Passwords
+    |--------------------------------------------------------------------------
+    |
+    | Here you may set the options for resetting passwords including the view
+    | that is your password reset e-mail. You may also set the name of the
+    | table that maintains all of the reset tokens for your application.
+    |
+    | You may specify multiple password reset configurations if you have more
+    | than one user table or model in the application and you want to have
+    | separate password reset settings based on the specific user types.
+    |
+    | The expire time is the number of minutes that the reset token should be
+    | considered valid. This security feature keeps tokens short-lived so
+    | they have less time to be guessed. You may change this as needed.
+    |
+    */
+
+    'passwords' => [
+        //
+    ],
+
+];

--- a/lumen/config/entrust.php
+++ b/lumen/config/entrust.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of Entrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Zizaco\Entrust
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Role Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the Role model used by Entrust to create correct relations.  Update
+    | the role if it is in a different namespace.
+    |
+    */
+    'role' => 'App\Role',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Roles Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the roles table used by Entrust to save roles to the database.
+    |
+    */
+    'roles_table' => 'roles',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Permission Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the Permission model used by Entrust to create correct relations.
+    | Update the permission if it is in a different namespace.
+    |
+    */
+    'permission' => 'App\Permission',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Permissions Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the permissions table used by Entrust to save permissions to the
+    | database.
+    |
+    */
+    'permissions_table' => 'permissions',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust permission_role Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the permission_role table used by Entrust to save relationship
+    | between permissions and roles to the database.
+    |
+    */
+    'permission_role_table' => 'permission_role',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust role_user Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the role_user table used by Entrust to save assigned roles to the
+    | database.
+    |
+    */
+    'role_user_table' => 'role_user',
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Foreign key on Entrust's role_user Table (Pivot)
+    |--------------------------------------------------------------------------
+    */
+    'user_foreign_key' => 'user_id',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Role Foreign key on Entrust's role_user Table (Pivot)
+    |--------------------------------------------------------------------------
+    */
+    'role_foreign_key' => 'role_id',
+
+];

--- a/lumen/database/migrations/2017_03_24_095856_add_users_table.php
+++ b/lumen/database/migrations/2017_03_24_095856_add_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('name');
+            $table->text('email')->unique();
+            $table->text('password');
+            $table->rememberToken('remember_token')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/lumen/database/migrations/2017_03_24_095856_add_users_table.php
+++ b/lumen/database/migrations/2017_03_24_095856_add_users_table.php
@@ -13,14 +13,16 @@ class AddUsersTable extends Migration
      */
     public function up()
     {
-        Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
-            $table->text('name');
-            $table->text('email')->unique();
-            $table->text('password');
-            $table->rememberToken('remember_token')->nullable();
-            $table->timestamps();
-        });
+        if(!Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->increments('id');
+                $table->text('name');
+                $table->text('email')->unique();
+                $table->text('password');
+                $table->rememberToken('remember_token')->nullable();
+                $table->timestamps();
+            });
+        }
     }
 
     /**

--- a/lumen/database/migrations/2017_03_24_095916_entrust_setup_tables.php
+++ b/lumen/database/migrations/2017_03_24_095916_entrust_setup_tables.php
@@ -1,0 +1,75 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class EntrustSetupTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return  void
+     */
+    public function up()
+    {
+        DB::beginTransaction();
+
+        // Create table for storing roles
+        Schema::create('roles', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->unique();
+            $table->string('display_name')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+
+        // Create table for associating roles to users (Many-to-Many)
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->integer('user_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+
+            $table->foreign('user_id')->references('id')->on('users')
+                ->onUpdate('cascade')->onDelete('cascade');
+            $table->foreign('role_id')->references('id')->on('roles')
+                ->onUpdate('cascade')->onDelete('cascade');
+
+            $table->primary(['user_id', 'role_id']);
+        });
+
+        // Create table for storing permissions
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->unique();
+            $table->string('display_name')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+
+        // Create table for associating permissions to roles (Many-to-Many)
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->integer('permission_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+
+            $table->foreign('permission_id')->references('id')->on('permissions')
+                ->onUpdate('cascade')->onDelete('cascade');
+            $table->foreign('role_id')->references('id')->on('roles')
+                ->onUpdate('cascade')->onDelete('cascade');
+
+            $table->primary(['permission_id', 'role_id']);
+        });
+
+        DB::commit();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return  void
+     */
+    public function down()
+    {
+        Schema::drop('permission_role');
+        Schema::drop('permissions');
+        Schema::drop('role_user');
+        Schema::drop('roles');
+    }
+}

--- a/lumen/database/migrations/2017_03_24_095916_entrust_setup_tables.php
+++ b/lumen/database/migrations/2017_03_24_095916_entrust_setup_tables.php
@@ -14,48 +14,56 @@ class EntrustSetupTables extends Migration
         DB::beginTransaction();
 
         // Create table for storing roles
-        Schema::create('roles', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name')->unique();
-            $table->string('display_name')->nullable();
-            $table->string('description')->nullable();
-            $table->timestamps();
-        });
+        if(!Schema::hasTable('roles')) {
+            Schema::create('roles', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name')->unique();
+                $table->string('display_name')->nullable();
+                $table->string('description')->nullable();
+                $table->timestamps();
+            });
+        }
 
         // Create table for associating roles to users (Many-to-Many)
-        Schema::create('role_user', function (Blueprint $table) {
-            $table->integer('user_id')->unsigned();
-            $table->integer('role_id')->unsigned();
+        if(!Schema::hasTable('role_user')) {
+            Schema::create('role_user', function (Blueprint $table) {
+                $table->integer('user_id')->unsigned();
+                $table->integer('role_id')->unsigned();
 
-            $table->foreign('user_id')->references('id')->on('users')
-                ->onUpdate('cascade')->onDelete('cascade');
-            $table->foreign('role_id')->references('id')->on('roles')
-                ->onUpdate('cascade')->onDelete('cascade');
+                $table->foreign('user_id')->references('id')->on('users')
+                    ->onUpdate('cascade')->onDelete('cascade');
+                $table->foreign('role_id')->references('id')->on('roles')
+                    ->onUpdate('cascade')->onDelete('cascade');
 
-            $table->primary(['user_id', 'role_id']);
-        });
+                $table->primary(['user_id', 'role_id']);
+            });
+        }
 
         // Create table for storing permissions
-        Schema::create('permissions', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name')->unique();
-            $table->string('display_name')->nullable();
-            $table->string('description')->nullable();
-            $table->timestamps();
-        });
+        if(!Schema::hasTable('permissions')) {
+            Schema::create('permissions', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name')->unique();
+                $table->string('display_name')->nullable();
+                $table->string('description')->nullable();
+                $table->timestamps();
+            });
+        }
 
         // Create table for associating permissions to roles (Many-to-Many)
-        Schema::create('permission_role', function (Blueprint $table) {
-            $table->integer('permission_id')->unsigned();
-            $table->integer('role_id')->unsigned();
+        if(!Schema::hasTable('permission_role')) {
+            Schema::create('permission_role', function (Blueprint $table) {
+                $table->integer('permission_id')->unsigned();
+                $table->integer('role_id')->unsigned();
 
-            $table->foreign('permission_id')->references('id')->on('permissions')
-                ->onUpdate('cascade')->onDelete('cascade');
-            $table->foreign('role_id')->references('id')->on('roles')
-                ->onUpdate('cascade')->onDelete('cascade');
+                $table->foreign('permission_id')->references('id')->on('permissions')
+                    ->onUpdate('cascade')->onDelete('cascade');
+                $table->foreign('role_id')->references('id')->on('roles')
+                    ->onUpdate('cascade')->onDelete('cascade');
 
-            $table->primary(['permission_id', 'role_id']);
-        });
+                $table->primary(['permission_id', 'role_id']);
+            });
+        }
 
         DB::commit();
     }

--- a/lumen/database/migrations/2017_03_24_100239_add_roles_and_permissions.php
+++ b/lumen/database/migrations/2017_03_24_100239_add_roles_and_permissions.php
@@ -1,0 +1,189 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\Permission;
+
+class AddRolesAndPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Permissions
+        // Add & Move thesaurus concepts
+        $add_move_concepts_th = new Permission();
+        $add_move_concepts_th->name = 'add_move_concepts_th';
+        $add_move_concepts_th->display_name = 'Add, move and relations of thesaurus concepts';
+        $add_move_concepts_th->description = 'add, move and add relations to concepts in thesaurex';
+        $add_move_concepts_th->save();
+        // Delete thesaurus concepts
+        $delete_concepts_th = new Permission();
+        $delete_concepts_th->name = 'delete_concepts_th';
+        $delete_concepts_th->display_name = 'Delete thesaurus concepts';
+        $delete_concepts_th->description = 'delete concepts in thesaurex';
+        $delete_concepts_th->save();
+        // Edit thesaurus concepts
+        $edit_concepts_th = new Permission();
+        $edit_concepts_th->name = 'edit_concepts_th';
+        $edit_concepts_th->display_name = 'Edit thesaurus concepts';
+        $edit_concepts_th->description = 'edit (modify labels) concepts in thesaurex';
+        $edit_concepts_th->save();
+        // Export thesaurus concepts
+        $export_th = new Permission();
+        $export_th->name = 'export_th';
+        $export_th->display_name = 'Export thesaurus concepts';
+        $export_th->description = 'export (sub-)trees in thesaurex';
+        $export_th->save();
+        // View thesaurus concepts
+        $view_concepts_th = new Permission();
+        $view_concepts_th->name = 'view_concepts_th';
+        $view_concepts_th->display_name = 'View thesaurus concepts';
+        $view_concepts_th->description = 'view concepts in thesaurex';
+        $view_concepts_th->save();
+        // View users
+        $cnt = DB::table('permissions')->where('name', '=', 'view_users')->count();
+        if($cnt === 0) {
+            $view_users = new Permission();
+            $view_users->name = 'view_users';
+            $view_users->display_name = 'View users';
+            $view_users->description = 'view all existing users';
+            $view_users->save();
+        } else {
+            $view_users = Permission::where('name', '=', 'view_users')->first();
+        }
+        // Create users
+        $cnt = DB::table('permissions')->where('name', '=', 'create_users')->count();
+        if($cnt === 0) {
+            $create_users = new Permission();
+            $create_users->name = 'create_users';
+            $create_users->display_name = 'Create users';
+            $create_users->description = 'create new users';
+            $create_users->save();
+        } else {
+            $create_users = Permission::where('name', '=', 'create_users')->first();
+        }
+        // Delete users
+        $cnt = DB::table('permissions')->where('name', '=', 'delete_users')->count();
+        if($cnt === 0) {
+            $delete_users = new Permission();
+            $delete_users->name = 'delete_users';
+            $delete_users->display_name = 'Delete users';
+            $delete_users->description = 'delete existing users';
+            $delete_users->save();
+        } else {
+            $delete_users = Permission::where('name', '=', 'delete_users')->first();
+        }
+        // Add/remove role
+        $cnt = DB::table('permissions')->where('name', '=', 'add_remove_role')->count();
+        if($cnt === 0) {
+            $add_remove_role = new Permission();
+            $add_remove_role->name = 'add_remove_role';
+            $add_remove_role->display_name = 'Add and remove roles';
+            $add_remove_role->description = 'add and remove roles from a user';
+            $add_remove_role->save();
+        } else {
+            $add_remove_role = Permission::where('name', '=', 'add_remove_role')->first();
+        }
+        // Change password
+        $cnt = DB::table('permissions')->where('name', '=', 'change_password')->count();
+        if($cnt === 0) {
+            $change_password = new Permission();
+            $change_password->name = 'change_password';
+            $change_password->display_name = 'Change password';
+            $change_password->description = 'change the password of a user';
+            $change_password->save();
+        } else {
+            $change_password = Permission::where('name', '=', 'change_password')->first();
+        }
+        // Add and edit roles
+        $cnt = DB::table('permissions')->where('name', '=', 'add_edit_role')->count();
+        if($cnt === 0) {
+            $add_edit_role = new Permission();
+            $add_edit_role->name = 'add_edit_role';
+            $add_edit_role->display_name = 'Add and edit roles';
+            $add_edit_role->description = 'add and edit existing roles';
+            $add_edit_role->save();
+        } else {
+            $add_edit_role = Permission::where('name', '=', 'add_edit_role')->first();
+        }
+        // Delete roles
+        $cnt = DB::table('permissions')->where('name', '=', 'delete_role')->count();
+        if($cnt === 0) {
+            $delete_role = new Permission();
+            $delete_role->name = 'delete_role';
+            $delete_role->display_name = 'Delete roles';
+            $delete_role->description = 'delete existing roles';
+            $delete_role->save();
+        } else {
+            $delete_role = Permission::where('name', '=', 'delete_role')->first();
+        }
+        // Add and remove permissions
+        $cnt = DB::table('permissions')->where('name', '=', 'add_remove_permission')->count();
+        if($cnt === 0) {
+            $add_remove_permission = new Permission();
+            $add_remove_permission->name = 'add_remove_permission';
+            $add_remove_permission->display_name = 'Add and remove permissions';
+            $add_remove_permission->description = 'add and remove permissions to/from roles';
+            $add_remove_permission->save();
+        } else {
+            $add_remove_permission = Permission::where('name', '=', 'add_remove_permission')->first();
+        }
+
+        // Roles
+        // Admin
+        $admin = new App\Role();
+        $admin->name = 'admin';
+        $admin->display_name = 'Administrator';
+        $admin->description = 'Project Administrator';
+        $admin->save();
+        // Add all permissions to admin
+        $admin->attachPermission($add_move_concepts_th);
+        $admin->attachPermission($delete_concepts_th);
+        $admin->attachPermission($edit_concepts_th);
+        $admin->attachPermission($export_th);
+        $admin->attachPermission($view_concepts_th);
+        $admin->attachPermission($view_users);
+        $admin->attachPermission($create_users);
+        $admin->attachPermission($delete_users);
+        $admin->attachPermission($add_remove_role);
+        $admin->attachPermission($change_password);
+        $admin->attachPermission($add_edit_role);
+        $admin->attachPermission($delete_role);
+        $admin->attachPermission($add_remove_permission);
+        // Guest
+        $guest = new App\Role();
+        $guest->name = 'guest';
+        $guest->display_name = 'Guest';
+        $guest->description = 'Guest User';
+        $guest->save();
+        $guest->attachPermission($view_concepts_th);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $permissions = [
+            'add_move_concepts_th', 'delete_concepts_th', 'edit_concepts_th', 'export_th', 'view_concepts_th'
+        ];
+        foreach($permissions as $p) {
+            $entry = Permission::where('name', '=', $p)->firstOrFail();
+            $entry->delete();
+        }
+        $roles = [
+            'admin', 'guest'
+        ];
+        foreach($roles as $r) {
+            $entry = App\Role::where('name', '=', $r)->firstOrFail();
+            $entry->delete();
+        }
+    }
+}

--- a/lumen/database/migrations/2017_03_24_100239_add_roles_and_permissions.php
+++ b/lumen/database/migrations/2017_03_24_100239_add_roles_and_permissions.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 use App\Permission;
+use App\Role;
 
 class AddRolesAndPermissions extends Migration
 {
@@ -136,31 +137,57 @@ class AddRolesAndPermissions extends Migration
 
         // Roles
         // Admin
-        $admin = new App\Role();
-        $admin->name = 'admin';
-        $admin->display_name = 'Administrator';
-        $admin->description = 'Project Administrator';
-        $admin->save();
+        $cnt = DB::table('roles')->where('name', '=', 'admin')->count();
+        if($cnt === 0) {
+            $admin = new Role();
+            $admin->name = 'admin';
+            $admin->display_name = 'Administrator';
+            $admin->description = 'Project Administrator';
+            $admin->save();
+        } else {
+            $admin = Role::where('name', '=', 'admin')->first();
+        }
         // Add all permissions to admin
         $admin->attachPermission($add_move_concepts_th);
         $admin->attachPermission($delete_concepts_th);
         $admin->attachPermission($edit_concepts_th);
         $admin->attachPermission($export_th);
         $admin->attachPermission($view_concepts_th);
-        $admin->attachPermission($view_users);
-        $admin->attachPermission($create_users);
-        $admin->attachPermission($delete_users);
-        $admin->attachPermission($add_remove_role);
-        $admin->attachPermission($change_password);
-        $admin->attachPermission($add_edit_role);
-        $admin->attachPermission($delete_role);
-        $admin->attachPermission($add_remove_permission);
+        if(!$admin->hasPermission('view_users')) {
+            $admin->attachPermission($view_users);
+        }
+        if(!$admin->hasPermission('create_users')) {
+            $admin->attachPermission($create_users);
+        }
+        if(!$admin->hasPermission('delete_users')) {
+            $admin->attachPermission($delete_users);
+        }
+        if(!$admin->hasPermission('add_remove_role')) {
+            $admin->attachPermission($add_remove_role);
+        }
+        if(!$admin->hasPermission('change_password')) {
+            $admin->attachPermission($change_password);
+        }
+        if(!$admin->hasPermission('add_edit_role')) {
+            $admin->attachPermission($add_edit_role);
+        }
+        if(!$admin->hasPermission('delete_role')) {
+            $admin->attachPermission($delete_role);
+        }
+        if(!$admin->hasPermission('add_remove_permission')) {
+            $admin->attachPermission($add_remove_permission);
+        }
         // Guest
-        $guest = new App\Role();
-        $guest->name = 'guest';
-        $guest->display_name = 'Guest';
-        $guest->description = 'Guest User';
-        $guest->save();
+        $cnt = DB::table('roles')->where('name', '=', 'guest')->count();
+        if($cnt === 0) {
+            $guest = new Role();
+            $guest->name = 'guest';
+            $guest->display_name = 'Guest';
+            $guest->description = 'Guest User';
+            $guest->save();
+        } else {
+            $guest = Role::where('name', '=', 'guest')->first();
+        }
         $guest->attachPermission($view_concepts_th);
     }
 
@@ -182,7 +209,7 @@ class AddRolesAndPermissions extends Migration
             'admin', 'guest'
         ];
         foreach($roles as $r) {
-            $entry = App\Role::where('name', '=', $r)->firstOrFail();
+            $entry = Role::where('name', '=', $r)->firstOrFail();
             $entry->delete();
         }
     }

--- a/lumen/database/migrations/2017_03_24_100346_add_default_admin_account.php
+++ b/lumen/database/migrations/2017_03_24_100346_add_default_admin_account.php
@@ -14,14 +14,21 @@ class AddDefaultAdminAccount extends Migration
      */
     public function up()
     {
-        $admin = new User();
-        $admin->name = 'Admin';
-        $admin->email = 'admin@admin.com';
-        $admin->password = Hash::make('admin');
-        $admin->save();
+        $adminName = 'Admin';
+        $cnt = User::where('name', '=', $adminName)->count();
+        if($cnt === 0) {
+            $admin = new User();
+            $admin->name = $adminName;
+            $admin->email = 'admin@admin.com';
+            $admin->password = Hash::make('admin');
+            $admin->save();
+        } else {
+            $admin = User::where('name', '=', $adminName)->first();
+        }
 
-        $adminRole = Role::where('name', '=', 'admin')->first();
-        $admin->attachRole($adminRole);
+        $adminRoleName = 'admin';
+        $adminRole = Role::where('name', '=', $adminRoleName)->first();
+        if(!$admin->hasRole($adminRoleName)) $admin->attachRole($adminRole);
     }
 
     /**

--- a/lumen/database/migrations/2017_03_24_100346_add_default_admin_account.php
+++ b/lumen/database/migrations/2017_03_24_100346_add_default_admin_account.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Hash;
+use App\User;
+use App\Role;
+
+class AddDefaultAdminAccount extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $admin = new User();
+        $admin->name = 'Admin';
+        $admin->email = 'admin@admin.com';
+        $admin->password = Hash::make('admin');
+        $admin->save();
+
+        $adminRole = Role::where('name', '=', 'admin')->first();
+        $admin->attachRole($adminRole);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        User::where('name', '=', 'Admin')->delete();
+    }
+}

--- a/lumen/database/seeds/GuestUserSeeder.php
+++ b/lumen/database/seeds/GuestUserSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\User;
+
+class GuestUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $guestName = 'Guest User';
+        $cnt = User::where('name', '=', $guestName)->count();
+        if($cnt === 0) {
+            $guest = new User();
+            $guest->name = $guestName;
+            $guest->email = 'udontneedtoseehisidentification@rebels.tld';
+            $guest->password = Hash::make('thesearentthedroidsuarelookingfor');
+            $guest->save();
+
+            $guestRole = App\Role::where('name', '=', 'guest')->firstOrFail();
+            $guest->attachRole($guestRole);
+        }
+    }
+}

--- a/lumen/routes/web.php
+++ b/lumen/routes/web.php
@@ -14,22 +14,39 @@
 $app->get('/', function () use ($app) {
     return $app->version();
 });
-$app->get('get/languages', 'TreeController@getLanguages');
-$app->post('import', 'TreeController@import');
-$app->post('export', 'TreeController@export');
-$app->post('get/relations', 'TreeController@getRelations');
-$app->post('remove/concept', 'TreeController@removeConcept');
-$app->post('delete/cascade', 'TreeController@deleteElementCascade');
-$app->post('delete/oneup', 'TreeController@deleteElementOneUp');
-$app->post('delete/totop', 'TreeController@deleteElementToTop');
-$app->post('get/tree', 'TreeController@getTree');
-$app->post('get/label', 'TreeController@getLabels');
-$app->post('get/label/display', 'TreeController@getDisplayLabel');
-$app->post('remove/label', 'TreeController@removeLabel');
-$app->post('add/broader', 'TreeController@addBroader');
-$app->post('add/concept', 'TreeController@addConcept');
-$app->post('add/label', 'TreeController@addLabel');
-$app->post('copy', 'TreeController@copy');
-$app->post('update/relation', 'TreeController@updateRelation');
-$app->post('search', 'TreeController@search');
-$app->post('get/parents/all', 'TreeController@getAllParents');
+
+$app->post('user/login', 'UserController@login');
+
+$app->group(['middleware' => ['before' => 'jwt.auth', 'after' => 'jwt.refresh']], function($app) {
+    $app->get('get/languages', 'TreeController@getLanguages');
+    $app->get('user/delete/{id}', 'UserController@delete');
+    $app->get('user/get/roles/all', 'UserController@getRoles');
+    $app->get('user/get/roles/{id}', 'UserController@getRolesByUser');
+    $app->get('user/get/role/permissions/{id}', 'UserController@getPermissionsByRole');
+    $app->post('import', 'TreeController@import');
+    $app->post('export', 'TreeController@export');
+    $app->post('get/relations', 'TreeController@getRelations');
+    $app->post('remove/concept', 'TreeController@removeConcept');
+    $app->post('delete/cascade', 'TreeController@deleteElementCascade');
+    $app->post('delete/oneup', 'TreeController@deleteElementOneUp');
+    $app->post('delete/totop', 'TreeController@deleteElementToTop');
+    $app->post('get/tree', 'TreeController@getTree');
+    $app->post('get/label', 'TreeController@getLabels');
+    $app->post('get/label/display', 'TreeController@getDisplayLabel');
+    $app->post('remove/label', 'TreeController@removeLabel');
+    $app->post('add/broader', 'TreeController@addBroader');
+    $app->post('add/concept', 'TreeController@addConcept');
+    $app->post('add/label', 'TreeController@addLabel');
+    $app->post('copy', 'TreeController@copy');
+    $app->post('update/relation', 'TreeController@updateRelation');
+    $app->post('search', 'TreeController@search');
+    $app->post('get/parents/all', 'TreeController@getAllParents');
+    $app->post('user/logout', 'UserController@logout');
+    $app->post('user/switch', 'UserController@switchRole');
+    $app->post('user/get', 'UserController@get');
+    $app->post('user/get/all', 'UserController@getAll');
+    $app->post('user/add', 'UserController@add');
+    $app->post('user/edit', 'UserController@edit');
+    $app->post('user/add/role', 'UserController@addRoleToUser');
+    $app->post('user/remove/role', 'UserController@removeRoleFromUser');
+});

--- a/roles.html
+++ b/roles.html
@@ -1,0 +1,62 @@
+<div ng-controller="userCtrl" resize-watcher>
+    <table class="table table-striped table-hover" ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role" ng-init="getRoles()">
+        <tr>
+            <th>
+                {{ 'role.name' }}
+            </th>
+            <th>
+                {{ 'role.display_name' }}
+            </th>
+            <th>
+                {{ 'role.description' }}
+            </th>
+            <th ng-if="currentUser.permissions.add_remove_permission">
+                {{ 'role.permissions' }}
+            </th>
+            <th ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role">
+                {{ 'role.options' }}
+            </th>
+            <th>
+                {{'user.created-at'}}
+            </th>
+            <th>
+                {{'user.updated-at'}}
+            </th>
+        </tr>
+        <tr ng-repeat="role in roles">
+            <td>
+                {{ role.name }}
+            </td>
+            <td>
+                {{ role.display_name }}
+            </td>
+            <td>
+                {{ role.description }}
+            </td>
+            <td ng-if="currentUser.permissions.add_remove_permission" ng-init="getRolePermissions(role)">
+                <ui-select multiple ng-model="role.permissions" close-on-select="false" name="role_permissions_{{ role.id }}" id="role_permissions_{{ role.id }}" on-select="addRolePermission($item, role)" on-remove="removeRolePermission($item, role)">
+                    <ui-select-match><span uib-tooltip="{{ $item.description }}">{{ $item.display_name }}</span></ui-select-match>
+                    <ui-select-choices repeat="permission in permissions | filter:$select.search">
+                        {{ permission.display_name }}
+                    </ui-select-choices>
+                </ui-select>
+            </td>
+            <th ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role">
+                <button type="button" class="btn btn-info" ng-click="openEditRoleDialog(role)" ng-if="currentUser.permissions.add_edit_role">
+                    <i class="fa fa-fw fa-pencil"></i>
+                </button> <button type="button" class="btn btn-danger" ng-click="deleteRole(role)" ng-if="currentUser.permissions.delete_role">
+                    <i class="fa fa-fw fa-trash-o"></i>
+                </button>
+            </th>
+            <td>
+                {{ role.created_at }}
+            </td>
+            <td>
+                {{ role.updated_at }}
+            </td>
+        </tr>
+    </table>
+    <button type="button" class="btn btn-success" ng-click="openAddRoleDialog()" ng-if="currentUser.permissions.add_edit_role">
+        <i class="fa fa-fw fa-plus"></i> {{ 'role.add' }}
+    </button>
+</div>

--- a/user.html
+++ b/user.html
@@ -1,0 +1,62 @@
+<div ng-controller="userCtrl" resize-watcher>
+    <table class="table table-striped table-hover" ng-init="getUserList()">
+        <tr>
+            <th>
+                {{'user.name'}}
+            </th>
+            <th>
+                {{'user.email'}}
+            </th>
+            <th ng-if="currentUser.permissions.change_password">
+                {{'user.password'}}
+            </th>
+            <th ng-if="currentUser.permissions.add_remove_role" ng-init="getRoles()">
+                {{'user.roles'}}
+            </th>
+            <th ng-if="currentUser.permissions.delete_users">
+                {{'user.delete'}}
+            </th>
+            <th>
+                {{'user.created-at'}}
+            </th>
+            <th>
+                {{'user.updated-at'}}
+            </th>
+        </tr>
+        <tr ng-repeat="user in users">
+            <td>
+                {{ user.name }}
+            </td>
+            <td>
+                {{ user.email }}
+            </td>
+            <td ng-if="currentUser.permissions.change_password">
+                <button type="button" class="btn btn-info" ng-click="openEditUserDialog(user, $index)">
+                    <i class="fa fa-fw fa-pencil"></i> {{'user.change-password'}}
+                </button>
+            </td>
+            <td ng-if="currentUser.permissions.add_remove_role" ng-init="getUserRoles(user.id, $index)">
+                <ui-select multiple ng-model="user.roles" close-on-select="false" name="userroles" id="userroles" on-select="addUserRole($item, user.id)" on-remove="removeUserRole($item, user.id)">
+                    <ui-select-match>{{ $item.display_name }}</ui-select-match>
+                    <ui-select-choices repeat="role in roles | filter:$select.search">
+                        {{ role.display_name }}
+                    </ui-select-choices>
+                </ui-select>
+            </td>
+            <td ng-if="currentUser.permissions.delete_users">
+                <button type="button" class="btn btn-danger" ng-click="deleteUser(user)">
+                    <i class="fa fa-fw fa-trash-o"></i>
+                </button>
+            </td>
+            <td>
+                {{ user.created_at }}
+            </td>
+            <td>
+                {{ user.updated_at }}
+            </td>
+        </tr>
+    </table>
+    <button type="button" class="btn btn-success" ng-click="openAddUserDialog()" ng-if="currentUser.permissions.create_users">
+        <i class="fa fa-fw fa-plus"></i> {{'user.add'}}
+    </button>
+</div>


### PR DESCRIPTION
Fix #85, #86 

This PR adds user management based on spacialist's user management. To test this branch please run `composer udpate`. A default admin account is created, if not created yet. To also add a guest account you have to exec (see https://github.com/eScienceCenter/Spacialist/pull/169):
```bash
composer dump-autoload
php artisan db:seed --class=GuestUserSeeder
```

It also adds basic permission checks. The UI should only display methods/actions accessable by the user. The master tree can still be modified by a user (with given permission of course). We should think of a way how to disable modifications in the master tree (relations, labels and drag&drop). Feel free to merge if this is good enough for now or add your requests. @eScienceCenter/spacialists 