### PR TITLE
use non-suffixed tables as project tables

### DIFF
--- a/lumen/app/Http/Controllers/TreeController.php
+++ b/lumen/app/Http/Controllers/TreeController.php
@@ -61,7 +61,7 @@ class TreeController extends Controller
         }
 
         $treeName = $request->get('treeName');
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
 
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
@@ -237,7 +237,7 @@ class TreeController extends Controller
         if($request->has('format')) $format = $request->get('format');
         else $format = 'rdf';
         $treeName = $request->get('treeName');
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
 
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
@@ -413,7 +413,7 @@ class TreeController extends Controller
         }
         $id = $request->get('id');
         $treeName = $request->get('treeName');
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
 
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
@@ -440,10 +440,10 @@ class TreeController extends Controller
         $treeName = $request->get('treeName');
 
         if($treeName === 'project') {
-            $suffix = '_export';
-            $labelView = 'getFirstLabelForLanguagesFromExport';
-        } else {
             $suffix = '';
+            $labelView = 'getFirstLabelForLanguagesFromProject';
+        } else {
+            $suffix = '_master';
             $labelView = 'getFirstLabelForLanguagesFromMaster';
         }
 
@@ -490,10 +490,10 @@ class TreeController extends Controller
         else $lang = 'de';
 
         if($which === 'project') {
-            $suffix = '_export';
-            $labelView = 'getFirstLabelForLanguagesFromExport';
-        } else {
             $suffix = '';
+            $labelView = 'getFirstLabelForLanguagesFromProject';
+        } else {
+            $suffix = '_master';
             $labelView = 'getFirstLabelForLanguagesFromMaster';
         }
         $thConcept = 'th_concept' . $suffix;
@@ -582,10 +582,10 @@ class TreeController extends Controller
         $treeName = $request->get('treeName');
 
         if($treeName === 'project') {
-            $suffix = '_export';
-            $labelView = 'getFirstLabelForLanguagesFromExport';
-        } else {
             $suffix = '';
+            $labelView = 'getFirstLabelForLanguagesFromProject';
+        } else {
+            $suffix = '_master';
             $labelView = 'getFirstLabelForLanguagesFromMaster';
         }
         $thConcept = 'th_concept' . $suffix;
@@ -636,7 +636,7 @@ class TreeController extends Controller
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
         $thBroader = 'th_broaders' . $suffix;
@@ -658,7 +658,7 @@ class TreeController extends Controller
         $broader_id = $request->get('broader_id');
         $treeName = $request->get('treeName');
 
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
         $thConcept = 'th_concept' . $suffix;
         $thBroader = 'th_broaders' . $suffix;
 
@@ -710,7 +710,7 @@ class TreeController extends Controller
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
-        $suffix = $treeName == 'project' ? '_export' : '';
+        $suffix = $treeName == 'project' ? '' : '_master';
 
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
@@ -864,7 +864,7 @@ class TreeController extends Controller
         $id = $request->get('id');
         $treeName = $request->get('treeName');
 
-        $suffix = $treeName === 'project' ? '_export' : '';
+        $suffix = $treeName === 'project' ? '' : '_master';
         $thLabel = 'th_concept_label' . $suffix;
 
         DB::table($thLabel)
@@ -950,18 +950,18 @@ class TreeController extends Controller
         $thLabel = 'th_concept_label';
         $thBroader = 'th_broaders';
         if($src == 'project') {
-            $thConceptSrc = $thConcept.'_export';
-            $thLabelSrc = $thLabel.'_export';
-            $thBroaderSrc = $thBroader.'_export';
-            $labelView = 'getFirstLabelForLanguagesFromMaster';
-        } else {
             $thConceptSrc = $thConcept;
             $thLabelSrc = $thLabel;
             $thBroaderSrc = $thBroader;
-            $thConcept .= '_export';
-            $thLabel .= '_export';
-            $thBroader .= '_export';
-            $labelView = 'getFirstLabelForLanguagesFromExport';
+            $thConcept .= '_master';
+            $thLabel .= '_master';
+            $thBroader .= '_master';
+            $labelView = 'getFirstLabelForLanguagesFromMaster';
+        } else {
+            $thConceptSrc = $thConcept . '_master';
+            $thLabelSrc = $thLabel . '_master';
+            $thBroaderSrc = $thBroader . '_master';
+            $labelView = 'getFirstLabelForLanguagesFromProject';
         }
 
         $rows = DB::select("
@@ -1140,10 +1140,10 @@ class TreeController extends Controller
         $treeName = $request->get('treeName');
 
         if($treeName === 'project') {
-            $suffix = '_export';
-            $labelView = 'getFirstLabelForLanguagesFromExport';
-        } else {
             $suffix = '';
+            $labelView = 'getFirstLabelForLanguagesFromProject';
+        } else {
+            $suffix = '_master';
             $labelView = 'getFirstLabelForLanguagesFromMaster';
         }
         $thConcept = 'th_concept' . $suffix;
@@ -1241,7 +1241,7 @@ class TreeController extends Controller
         if($request->has('lang')) $lang = $request->get('lang');
         else $lang = 'de';
 
-        $suffix = $which == 'project' ? '_export' : '';
+        $suffix = $which == 'project' ? '' : '_master';
         $thConcept = 'th_concept' . $suffix;
         $thLabel = 'th_concept_label' . $suffix;
         $thBroader = 'th_broaders' . $suffix;
@@ -1287,7 +1287,7 @@ class TreeController extends Controller
         if($request->has('treeName')) $which = $request->get('treeName');
         else $which = 'master';
 
-        $suffix = $which == 'project' ? '_export' : '';
+        $suffix = $which == 'project' ? '' : '_master';
         $thBroader = 'th_broaders' . $suffix;
 
         $parents = array();

--- a/lumen/app/ThBroader.php
+++ b/lumen/app/ThBroader.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThBroader extends Model
 {
-    protected $table = 'th_broaders';
+    protected $table = 'th_broaders_master';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/app/ThBroaderProject.php
+++ b/lumen/app/ThBroaderProject.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThBroaderProject extends Model
 {
-    protected $table = 'th_broaders_export';
+    protected $table = 'th_broaders';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/app/ThConcept.php
+++ b/lumen/app/ThConcept.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThConcept extends Model
 {
-    protected $table = 'th_concept';
+    protected $table = 'th_concept_master';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/app/ThConceptLabel.php
+++ b/lumen/app/ThConceptLabel.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThConceptLabel extends Model
 {
-    protected $table = 'th_concept_label';
+    protected $table = 'th_concept_label_master';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/app/ThConceptLabelProject.php
+++ b/lumen/app/ThConceptLabelProject.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThConceptLabelProject extends Model
 {
-    protected $table = 'th_concept_label_export';
+    protected $table = 'th_concept_label';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/app/ThConceptProject.php
+++ b/lumen/app/ThConceptProject.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ThConceptProject extends Model
 {
-    protected $table = 'th_concept_export';
+    protected $table = 'th_concept';
     /**
      * The attributes that are assignable.
      *

--- a/lumen/database/migrations/2017_04_11_101938_rename_th_tables.php
+++ b/lumen/database/migrations/2017_04_11_101938_rename_th_tables.php
@@ -1,0 +1,133 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameThTables extends Migration
+{
+    public $suffix = '_export';
+    public $newSuffix = '_master';
+    public $tables = ['th_concept', 'th_concept_label', 'th_broaders'];
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Drop getLabels view to recreate them with correct table names
+        Schema::getConnection()->statement('
+            DROP VIEW public."getFirstLabelForLanguagesFromMaster"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getFirstLabelForLanguagesFromExport"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getLabelsFromExport"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getLabelsFromMaster"
+        ');
+
+        // Rename tables
+        foreach($this->tables as $t) {
+            Schema::rename($t.$this->suffix, $t.$this->newSuffix);
+        }
+
+        // Recreate
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getLabelsFromMaster" AS
+            SELECT lbl.label,
+                con.concept_url,
+                lng.short_name
+            FROM th_concept_label_master lbl
+                JOIN th_language lng ON lbl.language_id = lng.id
+                JOIN th_concept_master con ON con.id = lbl.concept_id
+            ORDER BY con.id, lbl.concept_label_type
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getFirstLabelForLanguagesFromMaster" AS
+            SELECT "getLabelsFromMaster".concept_url,
+                "getLabelsFromMaster".short_name AS lang,
+                (array_agg("getLabelsFromMaster".label))[1] AS label
+            FROM "getLabelsFromMaster"
+                GROUP BY "getLabelsFromMaster".concept_url, "getLabelsFromMaster".short_name
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getLabelsFromProject" AS
+            SELECT lbl.label,
+                con.concept_url,
+                lng.short_name
+            FROM th_concept_label lbl
+                JOIN th_language lng ON lbl.language_id = lng.id
+                JOIN th_concept con ON con.id = lbl.concept_id
+            ORDER BY con.id, lbl.concept_label_type
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getFirstLabelForLanguagesFromProject" AS
+            SELECT "getLabelsFromProject".concept_url,
+                "getLabelsFromProject".short_name AS lang,
+                (array_agg("getLabelsFromProject".label))[1] AS label
+            FROM "getLabelsFromProject"
+                GROUP BY "getLabelsFromProject".concept_url, "getLabelsFromProject".short_name
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Drop getLabels view to recreate them with correct table names
+        Schema::getConnection()->statement('
+            DROP VIEW public."getFirstLabelForLanguagesFromMaster"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getFirstLabelForLanguagesFromProject"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getLabelsFromProject"
+        ');
+        Schema::getConnection()->statement('
+            DROP VIEW public."getLabelsFromMaster"
+        ');
+
+        // Rename tables
+        foreach($this->tables as $t) {
+            Schema::rename($t.$this->newSuffix, $t.$this->suffix);
+        }
+
+        // Recreate
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getLabelsFromMaster" AS
+            SELECT lbl.label,
+                con.concept_url,
+                lng.short_name
+            FROM th_concept_label lbl
+                JOIN th_language lng ON lbl.language_id = lng.id
+                JOIN th_concept con ON con.id = lbl.concept_id
+            ORDER BY con.id, lbl.concept_label_type
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getFirstLabelForLanguagesFromMaster" AS
+            SELECT "getLabelsFromMaster".concept_url,
+                "getLabelsFromMaster".short_name AS lang,
+                (array_agg("getLabelsFromMaster".label))[1] AS label
+            FROM "getLabelsFromMaster"
+                GROUP BY "getLabelsFromMaster".concept_url, "getLabelsFromMaster".short_name
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getLabelsFromExport" AS
+            SELECT lbl.label,
+                con.concept_url,
+                lng.short_name
+            FROM th_concept_label_export lbl
+                JOIN th_language lng ON lbl.language_id = lng.id
+                JOIN th_concept_export con ON con.id = lbl.concept_id
+            ORDER BY con.id, lbl.concept_label_type
+        ');
+        Schema::getConnection()->statement('CREATE OR REPLACE VIEW public."getFirstLabelForLanguagesFromExport" AS
+            SELECT "getLabelsFromExport".concept_url,
+                "getLabelsFromExport".short_name AS lang,
+                (array_agg("getLabelsFromExport".label))[1] AS label
+            FROM "getLabelsFromExport"
+                GROUP BY "getLabelsFromExport".concept_url, "getLabelsFromExport".short_name
+        ');
+    }
+}


### PR DESCRIPTION
Refs #86 

Thesaurus in Spacialist references now to the project thesaurus. Editing in the master tree is still possible, should be discussed and fixed in a later PR. For now it switches the trees so users don't get confused that changes in the master tree affect their Spacialist instance and changes in the project tree affect nothing.

**Please note**:
run `php artisan migrate`

Please review @eScienceCenter/spacialists 