### PR TITLE
add 'clear cache' action to menu

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -35,6 +35,10 @@ thesaurexApp.service('mainService', ['httpGetFactory', 'httpPostFactory', 'httpP
         message: ''
     };
 
+    main.clearCache = function() {
+        httpGetFactory('api/clear', function() {});
+    };
+
     main.createNewConceptModal = function(treeName, parent, name, expandFunction) {
         if(!isValidTreeName(treeName)) return;
         var modalInstance = $uibModal.open({

--- a/controllers/userCtrl.js
+++ b/controllers/userCtrl.js
@@ -1,10 +1,11 @@
-thesaurexApp.controller('userCtrl', ['$scope', 'userService', '$state', 'modalFactory', function($scope, userService, $state, modalFactory) {
+thesaurexApp.controller('userCtrl', ['$scope', 'userService', 'mainService', '$state', 'modalFactory', function($scope, userService, mainService, $state, modalFactory) {
     $scope.currentUser = userService.currentUser;
     $scope.users = userService.users;
     $scope.roles = userService.roles;
     $scope.permissions = userService.permissions;
     $scope.loginError = userService.loginError;
     $scope.deleteUser = userService.deleteUser;
+    $scope.clearCache = mainService.clearCache;
 
     $scope.loginUser = function(email, password) {
         var credentials = {

--- a/index.html
+++ b/index.html
@@ -50,6 +50,11 @@
                                         <i class="fa fa-fw fa-cog"></i> Role Management
                                     </a>
                                 </li>
+                                <li>
+                                    <a href="" ng-click="clearCache()">
+                                        <i class="fa fa-fw fa-refresh"></i> Clear Cache
+                                    </a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/lumen/routes/web.php
+++ b/lumen/routes/web.php
@@ -14,6 +14,9 @@
 $app->get('/', function () use ($app) {
     return $app->version();
 });
+$app->get('clear', function() use($app) {
+    Illuminate\Support\Facades\Artisan::call('cache:clear');
+});
 
 $app->post('user/login', 'UserController@login');
 


### PR DESCRIPTION
Temporary fix for the _Forbidden_ error. This adds a _clear cache_ route to the main menu. When a user gets the _Forbidden_ popup, they should click on the _Clear cache_ entry in the menu and refresh the page. Please merge @eScienceCenter/spacialists 