### PR TITLE
Fix seeder if admin role does not exist

### DIFF
--- a/lumen/database/seeds/RolesPermissionsSeeder.php
+++ b/lumen/database/seeds/RolesPermissionsSeeder.php
@@ -136,7 +136,14 @@ class RolesPermissionsSeeder extends Seeder
 
         // Roles
         // Admin
-        $admin = Role::where('name', '=', 'admin')->first();
+        $admin = Role::where('name', 'admin')->first();
+        if($admin === null) {
+            $admin = new Role();
+            $admin->name = 'admin';
+            $admin->display_name = 'Administrator';
+            $admin->description = 'Project Administrator';
+            $admin->save();
+        }
         // Add all permissions to admin
         $admin->attachPermission($add_move_concepts_th);
         $admin->attachPermission($delete_concepts_th);


### PR DESCRIPTION
I added a missing check for the admin role. If the role does not exist, it is created. Instead of expecting it exists...